### PR TITLE
Updated the parse method to throw an exception 

### DIFF
--- a/src/main/java/io/lindstrom/m3u8/parser/AbstractLineParser.java
+++ b/src/main/java/io/lindstrom/m3u8/parser/AbstractLineParser.java
@@ -38,7 +38,7 @@ abstract class AbstractLineParser<T> {
 
     abstract String writeAttributes(T value);
 
-    Map<String, String> parseAttributes(String attributeList) {
+    Map<String, String> parseAttributes(String attributeList) throws PlaylistParserException {
         Matcher matcher = ATTRIBUTE_LIST_PATTERN.matcher(attributeList);
         Map<String, String> attributes = new HashMap<>();
         while (matcher.find()) {

--- a/src/main/java/io/lindstrom/m3u8/parser/SegmentKeyParser.java
+++ b/src/main/java/io/lindstrom/m3u8/parser/SegmentKeyParser.java
@@ -53,15 +53,17 @@ class SegmentKeyParser extends AbstractLineParser<SegmentKey> {
     }
 
     @Override
-    Map<String, String> parseAttributes(String attributeList) {
+    Map<String, String> parseAttributes(String attributeList) throws PlaylistParserException {
         Matcher matcher = ATTRIBUTE_LIST_PATTERN.matcher(attributeList);
         Map<String, String> attributes = new HashMap<>();
         while (matcher.find()) {
             attributes.put(matcher.group(1), matcher.group(2) != null ? matcher.group(2) : matcher.group(3));
         }
-        Matcher keyFormatVersionMatcher = KEYFORMATVERSION_PATTERN.matcher(attributeList);
-        if (!keyFormatVersionMatcher.find()){
-            attributes.remove("KEYFORMATVERSIONS");
+        if (attributes.containsKey("KEYFORMATVERSIONS")) {
+            Matcher keyFormatVersionMatcher = KEYFORMATVERSION_PATTERN.matcher(attributeList);
+            if (!keyFormatVersionMatcher.find()) {
+                throw new PlaylistParserException("keyformatversions value is not formatted correctly");
+            }
         }
         return attributes;
     }

--- a/src/test/java/io/lindstrom/m3u8/parser/SegmentKeyParserTest.java
+++ b/src/test/java/io/lindstrom/m3u8/parser/SegmentKeyParserTest.java
@@ -28,8 +28,8 @@ public class SegmentKeyParserTest {
             "KEYFORMATVERSIONS=\"1/2/5\"";
 
     private String attributesWithNoQuotesOnKeyFormatVersion = "METHOD=SAMPLE-AES," +
-            "URI=\"skd://v/1301\"," +
-            "KEYFORMAT=\"com.apple.streamingkeydelivery\"," +
+            "URI=\"https://priv.example.com/key.php?r=53\"," +
+            "KEYFORMAT=\"identity\"," +
             "KEYFORMATVERSIONS=1/2/5";
 
     @Test
@@ -38,8 +38,14 @@ public class SegmentKeyParserTest {
     }
 
     @Test
-    public void parseKeyFormatVersionWithoutQuotes() throws Exception {
-        assertFalse(parser.parse(attributesWithNoQuotesOnKeyFormatVersion).keyFormatVersions().isPresent());
+    public void parseKeyFormatVersionWithoutQuotes() {
+        boolean thrown = false;
+        try {
+            parser.parse(attributesWithNoQuotesOnKeyFormatVersion);
+        } catch (PlaylistParserException e) {
+            thrown = true;
+        }
+        assertTrue("keyformatversion is formatted correctly",thrown);
     }
 
     @Test

--- a/src/test/java/io/lindstrom/m3u8/parser/SegmentKeyParserTest.java
+++ b/src/test/java/io/lindstrom/m3u8/parser/SegmentKeyParserTest.java
@@ -3,6 +3,7 @@ package io.lindstrom.m3u8.parser;
 import io.lindstrom.m3u8.model.KeyMethod;
 import io.lindstrom.m3u8.model.SegmentKey;
 import io.lindstrom.m3u8.parser.SegmentKeyParser;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import static io.lindstrom.m3u8.model.KeyMethod.AES_128;
@@ -21,11 +22,23 @@ public class SegmentKeyParserTest {
             .keyFormatVersions("1/2/5")
             .build();
 
+    private SegmentKey keyWithoutKeyFormatVersions = SegmentKey.builder()
+            .method(KeyMethod.AES_128)
+            .uri("https://priv.example.com/key.php?r=53")
+            .iv("0xc055ee9f6c1eb7aa50bfab02b0814972")
+            .keyFormat("identity")
+            .build();
+
     private String attributes = "METHOD=AES-128," +
             "URI=\"https://priv.example.com/key.php?r=53\"," +
             "IV=0xc055ee9f6c1eb7aa50bfab02b0814972," +
             "KEYFORMAT=\"identity\"," +
             "KEYFORMATVERSIONS=\"1/2/5\"";
+
+    private String attributesWithoutKeyFormatVersions = "METHOD=AES-128," +
+            "URI=\"https://priv.example.com/key.php?r=53\"," +
+            "IV=0xc055ee9f6c1eb7aa50bfab02b0814972," +
+            "KEYFORMAT=\"identity\"," ;
 
     private String attributesWithNoQuotesOnKeyFormatVersion = "METHOD=SAMPLE-AES," +
             "URI=\"https://priv.example.com/key.php?r=53\"," +
@@ -38,14 +51,15 @@ public class SegmentKeyParserTest {
     }
 
     @Test
+    public void parseAttributesWithoutKeyFormatVersions() throws Exception {
+        assertEquals(parser.parse(attributesWithoutKeyFormatVersions), keyWithoutKeyFormatVersions);
+    }
+
+    @Test
     public void parseKeyFormatVersionWithoutQuotes() {
-        boolean thrown = false;
-        try {
+        Assertions.assertThatThrownBy(()->{
             parser.parse(attributesWithNoQuotesOnKeyFormatVersion);
-        } catch (PlaylistParserException e) {
-            thrown = true;
-        }
-        assertTrue("keyformatversion is formatted correctly",thrown);
+        }).isInstanceOf(PlaylistParserException.class);
     }
 
     @Test


### PR DESCRIPTION
when the keyformatversion value doesn't have quotes and also update the test to check that parsing exception is thrown 